### PR TITLE
Benders for StochJuMP

### DIFF
--- a/src/BendersBridge.jl
+++ b/src/BendersBridge.jl
@@ -1,0 +1,272 @@
+using JuMP
+using StochJuMP
+
+include("Benders_pmap.jl")
+
+#===================================================
+ The following function is taken from JuMP
+ src/solvers.jl. Modified for extension 
+ StochJuMP/Benders_pmap.jl.
+===================================================#
+function conicconstraintdata(m::Model)
+    stoch = getStochastic(m)
+    parent = stoch.parent
+    numMasterCols = 0
+    if parent != nothing
+        numMasterCols = parent.numCols
+    end
+    v = Symbol[]
+    obj_coeff = zeros(m.numCols)
+    for i in 1:length(m.obj.aff.vars)
+        var = m.obj.aff.vars[i]
+        coeff = m.obj.aff.coeffs[i]
+        obj_coeff[var.col] = coeff
+    end
+
+    var_cones = Any[cone for cone in m.varCones]
+    con_cones = Any[]
+    nnz = 0
+
+    linconstr = m.linconstr
+    numLinRows = length(linconstr)
+    numBounds = 0
+    nonNeg  = Int[]
+    nonPos  = Int[]
+    free    = Int[]
+    zeroVar = Int[]
+    for i in 1:m.numCols
+        seen = false
+        lb, ub = m.colLower[i], m.colUpper[i]
+        for (_,cone) in m.varCones
+            if i in cone
+                seen = true
+                @assert lb == -Inf && ub == Inf
+                break
+            end
+        end
+
+        if !seen
+            if lb != -Inf
+                numBounds += 1
+            end
+            if ub != Inf
+                numBounds += 1
+            end
+            if lb == 0 && ub == 0
+                push!(zeroVar, i)
+            elseif lb == 0
+                push!(nonNeg, i)
+            elseif ub == 0
+                push!(nonPos, i)
+            else
+                push!(free, i)
+            end
+        end
+    end
+
+    if !isempty(zeroVar)
+        push!(var_cones, (:Zero,zeroVar))
+    end
+    if !isempty(nonNeg)
+        push!(var_cones, (:NonNeg,nonNeg))
+    end
+    if !isempty(nonPos)
+        push!(var_cones, (:NonPos,nonPos))
+    end
+    if !isempty(free)
+        push!(var_cones, (:Free,free))
+    end
+
+    nnz += numBounds
+    for c in 1:numLinRows
+        nnz += length(linconstr[c].terms.coeffs)
+    end
+
+    numSOCRows = 0
+    for con in m.socconstr
+        numSOCRows += length(con.normexpr.norm.terms) + 1
+    end
+    numRows = numLinRows + numBounds + numSOCRows
+
+    b = Array(Float64, numRows)
+
+    I_m = Int[]
+    J_m = Int[]
+    V_m = Float64[]
+    I_s = Int[]
+    J_s = Int[]
+    V_s = Float64[]
+
+    # Fill it up
+    nnz = 0
+    tmprow = JuMP.IndexedVector(Float64,m.numCols)
+    tmpelts = tmprow.elts
+    tmpnzidx = tmprow.nzidx
+    nonneg_rows = Int[]
+    nonpos_rows = Int[]
+    eq_rows     = Int[]
+    for c in 1:numLinRows
+        if linconstr[c].lb == -Inf
+            b[c] = linconstr[c].ub
+            push!(nonneg_rows, c)
+        elseif linconstr[c].ub == Inf
+            b[c] = linconstr[c].lb
+            push!(nonpos_rows, c)
+        elseif linconstr[c].lb == linconstr[c].ub
+            b[c] = linconstr[c].lb
+            push!(eq_rows, c)
+        else
+            error("We currently do not support ranged constraints with conic solvers")
+        end
+
+        JuMP.assert_isfinite(linconstr[c].terms)
+        coeffs = linconstr[c].terms.coeffs
+        vars = linconstr[c].terms.vars
+        # eliminated collect duplicates
+        for ind in 1:length(coeffs)
+            if vars[ind].m == parent
+                push!(I_m, c)
+                push!(J_m, vars[ind].col)
+                push!(V_m, coeffs[ind])
+            else
+                push!(I_s, c)
+                push!(J_s, vars[ind].col)
+                push!(V_s, coeffs[ind])
+            end
+        end
+    end
+
+    c = numLinRows
+    bndidx = 0
+    for idx in 1:m.numCols
+        lb = m.colLower[idx]
+        str = Symbol(m.colNames[idx])
+        # identify integrality information
+        push!(v, getCategory(m.varDict[str]))
+        if lb != -Inf
+            bndidx += 1
+            nnz += 1
+            c   += 1
+            (m.varDict[str].m == parent) && push!(I_m, c)
+            (m.varDict[str].m == parent) && push!(J_m, idx)
+            (m.varDict[str].m == parent) && push!(V_m, 1.0)
+            (m.varDict[str].m != parent) && push!(I_s, c)
+            (m.varDict[str].m != parent) && push!(J_s, idx)
+            (m.varDict[str].m != parent) && push!(V_s, 1.0)
+            b[c] = lb
+            push!(nonpos_rows, c)
+        end
+        ub = m.colUpper[idx]
+        if ub != Inf
+            bndidx += 1
+            c   += 1
+            (m.varDict[str].m == parent) && push!(I_m, c)
+            (m.varDict[str].m == parent) && push!(J_m, idx)
+            (m.varDict[str].m == parent) && push!(V_m, 1.0)
+            (m.varDict[str].m != parent) && push!(I_s, c)
+            (m.varDict[str].m != parent) && push!(J_s, idx)
+            (m.varDict[str].m != parent) && push!(V_s, 1.0)
+            b[c] = ub
+            push!(nonneg_rows, c)
+        end
+    end
+
+    if !isempty(nonneg_rows)
+        push!(con_cones, (:NonNeg,nonneg_rows))
+    end
+    if !isempty(nonpos_rows)
+        push!(con_cones, (:NonPos,nonpos_rows))
+    end
+    if !isempty(eq_rows)
+        push!(con_cones, (:Zero,eq_rows))
+    end
+    #@assert c == numLinRows + numBounds
+
+    tmpelts = tmprow.elts
+    tmpnzidx = tmprow.nzidx
+    socidx = 0
+    for con in m.socconstr
+        socidx += 1
+        expr = con.normexpr
+        c += 1
+        soc_start = c
+        JuMP.collect_expr!(m, tmprow, expr.aff)
+        nnz = tmprow.nnz
+        indices = tmpnzidx[1:nnz]
+        vars = expr.aff.vars
+        for i = 1:length(vars)
+            if vars[i].m == parent
+                push!(I_m, c)
+                push!(J_m, indices[i])
+                push!(V_m, tmpelts[indices[i]])
+            else
+                push!(I_s, c)
+                push!(J_s, indices[i])
+                push!(V_s, tmpelts[indices[i]])
+            end
+        end
+        b[c] = -expr.aff.constant
+        for term in expr.norm.terms
+            c += 1
+            JuMP.collect_expr!(m, tmprow, term)
+            nnz = tmprow.nnz
+            indices = tmpnzidx[1:nnz]
+            vars = term.vars
+            for i = 1:length(vars)
+                if vars[i].m == parent
+                    push!(I_m, c)
+                    push!(J_m, indices[i])
+                    push!(V_m, -expr.coeff*tmpelts[indices[i]])
+                else
+                    push!(I_s, c)
+                    push!(J_s, indices[i])
+                    push!(V_s, -expr.coeff*tmpelts[indices[i]])
+                end
+            end
+            b[c] = expr.coeff*term.constant
+        end
+        push!(con_cones, (:SOC, soc_start:c))
+    end
+    #@assert c == numLinRows + numBounds + numQuadRows + numSOCRows
+
+    A = sparse(I_m, J_m, V_m, numRows, numMasterCols)#, numRows, m.numCols)
+    B = sparse(I_s, J_s, V_s, numRows, m.numCols)#, numRows, m.numCols)
+  
+    return obj_coeff, A, B, b, var_cones, con_cones, v
+end
+
+function BendersBridge(m::Model, master_solver, sub_solver)
+
+    c_all = Any[]
+    A_all = Any[]
+    B_all = Any[]
+    b_all = Any[]
+    K_all = Any[]
+    C_all = Any[]
+    v_all = Symbol[]
+
+    (c,A,B,b,var_cones, constr_cones, v) = conicconstraintdata(m)
+    push!(c_all, c)
+    push!(A_all, B)
+    push!(b_all, b)
+    push!(K_all, constr_cones)
+    push!(C_all, var_cones)
+    append!(v_all, v)
+
+    for i = 1:length(m.ext[:Stochastic].children)
+        (c,A,B,b,var_cones, constr_cones, v) = conicconstraintdata(m.ext[:Stochastic].children[i])
+        push!(c_all, c)
+        push!(A_all, A)
+        push!(B_all, B)
+        push!(b_all, b)
+        push!(K_all, constr_cones)
+        push!(C_all, var_cones)
+        append!(v_all, v)
+
+    end
+
+    println("Entering Benders")
+    return Benders_pmap(c_all,A_all,B_all,b_all,K_all,C_all,v_all,master_solver,sub_solver)
+
+
+end

--- a/src/BendersBridge.jl
+++ b/src/BendersBridge.jl
@@ -258,8 +258,6 @@ function BendersBridge(m::Model, master_solver, sub_solver)
 
     end
 
-    @show A_all
-    @show B_all
     println("Entering Benders")
     return Benders_pmap(c_all,A_all,B_all,b_all,K_all,C_all,v_all,master_solver,sub_solver)
 

--- a/src/BendersBridge.jl
+++ b/src/BendersBridge.jl
@@ -140,20 +140,15 @@ function conicconstraintdata(m::Model)
     bndidx = 0
     for idx in 1:m.numCols
         lb = m.colLower[idx]
-        # get a variable handle
-        var = Variable(m, idx)
         # identify integrality information
         push!(v, m.colCat[idx])
         if lb != -Inf
             bndidx += 1
             nnz += 1
             c   += 1
-            (var.m === parent) && push!(I_m, c)
-            (var.m === parent) && push!(J_m, idx)
-            (var.m === parent) && push!(V_m, 1.0)
-            (var.m !== parent) && push!(I_s, c)
-            (var.m !== parent) && push!(J_s, idx)
-            (var.m !== parent) && push!(V_s, 1.0)
+            push!(I_s, c)
+            push!(J_s, idx)
+            push!(V_s, 1.0)
             b[c] = lb
             push!(nonpos_rows, c)
         end
@@ -161,12 +156,9 @@ function conicconstraintdata(m::Model)
         if ub != Inf
             bndidx += 1
             c   += 1
-            (var.m == parent) && push!(I_m, c)
-            (var.m == parent) && push!(J_m, idx)
-            (var.m == parent) && push!(V_m, 1.0)
-            (var.m != parent) && push!(I_s, c)
-            (var.m != parent) && push!(J_s, idx)
-            (var.m != parent) && push!(V_s, 1.0)
+            push!(I_s, c)
+            push!(J_s, idx)
+            push!(V_s, 1.0)
             b[c] = ub
             push!(nonneg_rows, c)
         end
@@ -266,6 +258,8 @@ function BendersBridge(m::Model, master_solver, sub_solver)
 
     end
 
+    @show A_all
+    @show B_all
     println("Entering Benders")
     return Benders_pmap(c_all,A_all,B_all,b_all,K_all,C_all,v_all,master_solver,sub_solver)
 

--- a/src/Benders_pmap.jl
+++ b/src/Benders_pmap.jl
@@ -127,7 +127,7 @@ function addCuttingPlanes(master_model, num_scen, A_all, b_all, output, x, θ, s
 
 end
 
-function Benders_pmap(c_all, A_all, B_all, b_all, K_all, C_all, v, master_solver, sub_solver, TOL)
+function Benders_pmap(c_all, A_all, B_all, b_all, K_all, C_all, v, master_solver, sub_solver, TOL=1e-5)
 
     println("Benders pmap started")
     num_master_var = length(c_all[1])

--- a/test/benderstest.jl
+++ b/test/benderstest.jl
@@ -14,7 +14,7 @@ facts("[Benders] Empty scenario test") do
     m = StochasticModel(0)
     @defVar(m, x, Int)
     @addConstraint(m, x <= 4)
-    setObjective(m, :Min, -5*x)
+    @setObjective(m, :Min, -5*x)
 
     output = BendersBridge(m, misocp_solver, socp_solver) 
 
@@ -31,13 +31,13 @@ facts("[Benders] Infeasible problem test") do
     @defVar(m, x, Int)
 
     @addConstraint(m, x <= 1)
-    setObjective(m, :Min, -5*x)
+    @setObjective(m, :Min, -5*x)
 
     bl = StochasticBlock(m)
     @defVar(bl, y1 >= 2)
     @defVar(bl, y2 <= 2)
     @addConstraint(bl, x >= y1)
-    @addConstraint(bl, norm([y1]) <= y2)
+    @addConstraint(bl, norm(y1) <= y2)
     @setObjective(bl, Min, 2*y1 + y2)
 
     output = BendersBridge(m, misocp_solver, socp_solver) 
@@ -54,13 +54,13 @@ facts("[Benders] Infeasibility cut execution test #1") do
     @defVar(m, x, Int)
 
     @addConstraint(m, x <= 4)
-    setObjective(m, :Min, -5*x)
+    @setObjective(m, :Min, -5*x)
 
     bl = StochasticBlock(m)
     @defVar(bl, y1 >= 0)
     @defVar(bl, y2 <= 2)
     @addConstraint(bl, x <= y1)
-    @addConstraint(bl, norm([y1]) <= y2)
+    @addConstraint(bl, norm(y1) <= y2)
     @setObjective(bl, Min, 2*y1 + y2)
 
     output = BendersBridge(m, misocp_solver, socp_solver) 
@@ -78,13 +78,13 @@ facts("[Benders] Optimality cut execution test #1") do
     @defVar(m, x, Int)
 
     @addConstraint(m, x <= 4)
-    setObjective(m, :Min, -5*x)
+    @setObjective(m, :Min, -5*x)
 
     bl = StochasticBlock(m)
     @defVar(bl, y1 >= 2)
     @defVar(bl, y2 <= 4)
     @addConstraint(bl, x <= y1)
-    @addConstraint(bl, norm([y1]) <= y2)
+    @addConstraint(bl, norm(y1) <= y2)
     @setObjective(bl, Min, 2*y1 + y2)
 
     output = BendersBridge(m, misocp_solver, socp_solver) 

--- a/test/benderstest.jl
+++ b/test/benderstest.jl
@@ -1,0 +1,95 @@
+using JuMP
+using StochJuMP
+using CPLEX
+using ECOS
+using FactCheck
+
+include("../src/BendersBridge.jl")
+
+misocp_solver = CplexSolver()
+socp_solver = ECOS.ECOSSolver()
+
+facts("[Benders] Empty scenario test") do
+
+    m = StochasticModel(0)
+    @defVar(m, x, Int)
+    @addConstraint(m, x <= 4)
+    setObjective(m, :Min, -5*x)
+
+    output = BendersBridge(m, misocp_solver, socp_solver) 
+
+    @fact output[1] --> :Optimal
+    @fact output[2] --> roughly(-20.0)
+
+end
+
+facts("[Benders] Infeasible problem test") do
+
+    numScen = 1
+    m = StochasticModel(numScen)
+
+    @defVar(m, x, Int)
+
+    @addConstraint(m, x <= 1)
+    setObjective(m, :Min, -5*x)
+
+    bl = StochasticBlock(m)
+    @defVar(bl, y1 >= 2)
+    @defVar(bl, y2 <= 2)
+    @addConstraint(bl, x >= y1)
+    @addConstraint(bl, norm([y1]) <= y2)
+    @setObjective(bl, Min, 2*y1 + y2)
+
+    output = BendersBridge(m, misocp_solver, socp_solver) 
+    
+    @fact output[1] --> :Infeasible
+
+end
+
+facts("[Benders] Infeasibility cut execution test #1") do
+
+    numScen = 1
+    m = StochasticModel(numScen)
+
+    @defVar(m, x, Int)
+
+    @addConstraint(m, x <= 4)
+    setObjective(m, :Min, -5*x)
+
+    bl = StochasticBlock(m)
+    @defVar(bl, y1 >= 0)
+    @defVar(bl, y2 <= 2)
+    @addConstraint(bl, x <= y1)
+    @addConstraint(bl, norm([y1]) <= y2)
+    @setObjective(bl, Min, 2*y1 + y2)
+
+    output = BendersBridge(m, misocp_solver, socp_solver) 
+    
+    @fact output[1] --> :Optimal
+    @fact output[2] --> roughly(-4.0)
+
+end
+
+facts("[Benders] Optimality cut execution test #1") do
+
+    numScen = 1
+    m = StochasticModel(numScen)
+
+    @defVar(m, x, Int)
+
+    @addConstraint(m, x <= 4)
+    setObjective(m, :Min, -5*x)
+
+    bl = StochasticBlock(m)
+    @defVar(bl, y1 >= 2)
+    @defVar(bl, y2 <= 4)
+    @addConstraint(bl, x <= y1)
+    @addConstraint(bl, norm([y1]) <= y2)
+    @setObjective(bl, Min, 2*y1 + y2)
+
+    output = BendersBridge(m, misocp_solver, socp_solver) 
+    
+    @fact output[1] --> :Optimal
+    @fact output[2] --> roughly(-8.0)
+
+end


### PR DESCRIPTION
This PR adds a parallel Benders algorithm to StochJuMP. It can be called with a given misocp_solver and socp_solver for subproblems. Added a simple set of unit tests to verify functionality.